### PR TITLE
Rename "destroy!" to "hard_destroy"

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -14,13 +14,13 @@ h3. Details
 This changes the behavior of the +destroy+ method to become a soft-destroy, which
 will set the +deleted_at+ attribute to <tt>Time.now</tt>, and the +deleted+ attribute to <tt>true</tt>
 It exposes the +revive+ method to reverse the effects of +destroy+ (for :dependent => :destroy associations only).
-It also exposes the +destroy!+ method which can be used to <b>really</b> destroy an object and it's associations.
+It also exposes the +hard_destroy+ method which can be used to <b>really</b> destroy an object and it's associations.
 
 +revive+ will not revive child associations which have been destroyed by actions other a destroy of the parent.
 This requires the column attribute +revive_with_parent+.
 
 Standard ActiveRecord destroy callbacks are _not_ called, however you can override +before_soft_destroy+, +after_soft_destroy+,
-and +before_destroy!+ on your soft_destroyable models.
+and +before_hard_destroy+ on your soft_destroyable models.
 
 Most standard ActiveRecord dependent options are supported and will behave as expected: :destroy, :restrict_with_exception, :nullify, :delete_all, and :delete.
 The option :restrict_with_error is not fully supported and will behave like :restrict_with_exception.
@@ -32,7 +32,7 @@ Note: The dependent :delete option will delete `has_many` children but nullify `
 
 The +delete+ operation is _not_ modified by this module.
 
-The operations: +destroy+, +destroy!+, and +revive+ are automatically delegated to the dependent association records.
+The operations: +destroy+, +hard_destroy+, and +revive+ are automatically delegated to the dependent association records.
 in a single transaction.
 
 Scopes are provided for +deleted+ and +not_deleted+.   The standard +all+ scope is not polluted, so will still

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -25,8 +25,8 @@ class BasicTest < Test::Unit::TestCase
     assert !Parent.deleted.include?(@fred)
   end
 
-  def test_destroy!
-    @fred.destroy!
+  def test_hard_destroy
+    @fred.hard_destroy
     assert_nil Parent.where(:name => "fred").first
   end
 

--- a/test/callback_test.rb
+++ b/test/callback_test.rb
@@ -28,7 +28,7 @@ class CallbackTest < Test::Unit::TestCase
   def test_callback_before_destroy_bang_for_soft_children
     @fred.soft_callback_children << pebbles = SoftCallbackChild.new(:name => "pebbles")
     assert_raise PreventDestroyBangError do
-      @fred.destroy!
+      @fred.hard_destroy
     end
     assert_equal @fred.reload.deleted?, false
     assert_equal pebbles.reload.deleted?, false
@@ -43,10 +43,10 @@ class CallbackTest < Test::Unit::TestCase
     assert_not_nil pebbles.reload
   end
 
-  def test_callback_before_destroy!
+  def test_callback_before_hard_destroy
     @fred.callback_children << pebbles = CallbackChild.new(:name => "pebbles")
     assert_raise PreventDestroyBangError do
-      @fred.destroy!
+      @fred.hard_destroy
     end
     assert_equal @fred.reload.deleted?, false
     assert_not_nil pebbles.reload
@@ -64,7 +64,7 @@ class CallbackTest < Test::Unit::TestCase
     @fred = Parent.create!(:name => "fred")
     @fred.soft_children << pebbles = SoftChild.new(:name => "pebbles")
     previous_updated_at = @fred.updated_at
-    pebbles.destroy!
+    pebbles.hard_destroy
     assert_not_equal @fred.reload.updated_at, previous_updated_at
   end
 

--- a/test/class_method_test.rb
+++ b/test/class_method_test.rb
@@ -56,8 +56,8 @@ class ClassMethodTest < Test::Unit::TestCase
     assert Parent.restrict_dependencies.include? :restrict_one
   end
 
-  def test_respond_to_destroy!
-    assert @fred.respond_to?(:destroy!)
+  def test_respond_to_hard_destroy
+    assert @fred.respond_to?(:hard_destroy)
   end
 
   def test_respond_to_deleted_scope

--- a/test/dependent_delete_all_test.rb
+++ b/test/dependent_delete_all_test.rb
@@ -39,7 +39,7 @@ class DependentDeleteAllTest < Test::Unit::TestCase
     @fred.soft_delete_all_children << pebbles = SoftDeleteAllChild.new(:name => "pebbles")
     @fred.soft_delete_all_children << bambam = SoftDeleteAllChild.new(:name => "bambam")
     assert_equal 2, @fred.reload.soft_delete_all_children.count
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_id(@fred.id)
     assert_equal 0, SoftDeleteAllChild.where(:name => "pebbles").count
     assert_equal 0, SoftDeleteAllChild.where(:name => "bambam").count
@@ -50,7 +50,7 @@ class DependentDeleteAllTest < Test::Unit::TestCase
     @fred.delete_all_children << pebbles = DeleteAllChild.new(:name => "pebbles")
     @fred.delete_all_children << bambam = DeleteAllChild.new(:name => "bambam")
     assert_equal 2, @fred.reload.delete_all_children.count
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_id(@fred.id)
     assert_equal 0, DeleteAllChild.where(:name => "pebbles").count
     assert_equal 0, DeleteAllChild.where(:name => "bambam").count

--- a/test/dependent_delete_test.rb
+++ b/test/dependent_delete_test.rb
@@ -35,7 +35,7 @@ class DependentDeleteTest < Test::Unit::TestCase
     @fred.soft_delete_one = pebbles = SoftDeleteOne.new(:name => "pebbles")
     assert_equal pebbles, @fred.reload.soft_delete_one
     assert_equal @fred, pebbles.parent
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_id(@fred.id)
     assert_equal 0, SoftDeleteOne.where(:name => "pebbles", :parent_id => @fred.id).count
     assert_equal 1, SoftDeleteOne.where(:name => "pebbles").count
@@ -44,7 +44,7 @@ class DependentDeleteTest < Test::Unit::TestCase
   def test_destroy_bang_has_one_delete_one
     @fred.delete_one = pebbles = DeleteOne.new(:name => "pebbles")
     assert_equal pebbles, @fred.reload.delete_one
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_id(@fred.id)
     assert_equal 0, DeleteOne.where(:name => "pebbles", :parent_id => @fred.id).count
     assert_equal 1, DeleteOne.where(:name => "pebbles").count

--- a/test/dependent_destroy_test.rb
+++ b/test/dependent_destroy_test.rb
@@ -42,7 +42,7 @@ class DependentDestroyTest < Test::Unit::TestCase
     @fred.soft_children << SoftChild.new(:name => "pebbles")
     @fred.soft_children << SoftChild.new(:name => "bambam")
     assert_equal @fred.reload.soft_children.count, 2
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_name("fred")
     assert_nil SoftChild.find_by_name("pebbles")
     assert_nil SoftChild.find_by_name("bambam")
@@ -52,7 +52,7 @@ class DependentDestroyTest < Test::Unit::TestCase
     @fred.children << Child.new(:name => "pebbles")
     @fred.children << Child.new(:name => "bambam")
     assert_equal @fred.reload.children.count, 2
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_name("fred")
     assert_nil Child.find_by_name("pebbles")
     assert_nil Child.find_by_name("bambam")
@@ -79,7 +79,7 @@ class DependentDestroyTest < Test::Unit::TestCase
   def test_destroy_bang_has_soft_ones
     @fred.soft_one = SoftOne.new(:name => "bambam")
     assert_equal @fred.reload.soft_one, SoftOne.where(:name => "bambam", :parent_id => @fred.id).first
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_name("fred")
     assert_nil SoftOne.find_by_name("bambam")
   end
@@ -87,7 +87,7 @@ class DependentDestroyTest < Test::Unit::TestCase
   def test_destroy_bang_has_ones
     @fred.one = One.new(:name => "bambam")
     assert_equal @fred.reload.one, One.where(:name => "bambam", :parent_id => @fred.id).first
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_name("fred")
     assert_nil One.find_by_name("bambam")
   end

--- a/test/dependent_nullify_test.rb
+++ b/test/dependent_nullify_test.rb
@@ -60,7 +60,7 @@ class DependentNullifyTest < Test::Unit::TestCase
     @fred.soft_nullify_children << bambam = SoftNullifyChild.new(:name => "bambam")
     assert_equal 2, @fred.reload.soft_nullify_children.count
     assert_equal @fred, pebbles.parent
-    @fred.destroy!
+    @fred.hard_destroy
     assert_equal 1, SoftNullifyChild.where(:name => "pebbles", :parent_id => nil).count
     assert_equal 1, SoftNullifyChild.where(:name => "bambam", :parent_id => nil).count
   end
@@ -70,7 +70,7 @@ class DependentNullifyTest < Test::Unit::TestCase
     @fred.nullify_children << bambam = NullifyChild.new(:name => "bambam")
     assert_equal 2, @fred.reload.nullify_children.count
     assert_equal @fred, pebbles.parent
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil pebbles.reload.parent
     assert_nil bambam.reload.parent
   end
@@ -79,7 +79,7 @@ class DependentNullifyTest < Test::Unit::TestCase
     @fred.soft_nullify_one = bambam = SoftNullifyOne.new(:name => "bambam")
     assert_equal bambam, @fred.reload.soft_nullify_one
     assert_equal bambam.parent, @fred
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_name("fred")
     assert_nil bambam.reload.parent
   end
@@ -88,7 +88,7 @@ class DependentNullifyTest < Test::Unit::TestCase
     @fred.nullify_one = bambam = NullifyOne.new(:name => "bambam")
     assert_equal bambam, @fred.reload.nullify_one
     assert_equal bambam.parent, @fred
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_name("fred")
     assert_nil bambam.reload.parent
   end

--- a/test/dependent_restrict_test.rb
+++ b/test/dependent_restrict_test.rb
@@ -20,7 +20,7 @@ class DependentRestrictTest < Test::Unit::TestCase
   end
 
   def test_destroy_bang_no_restrict_or_soft_restrict_children
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_id(@fred.id)
   end
 
@@ -64,7 +64,7 @@ class DependentRestrictTest < Test::Unit::TestCase
     @fred.soft_restrict_children << bambam = SoftRestrictChild.new(:name => "bambam")
     assert_equal 2, @fred.reload.soft_restrict_children.count
     assert_raise ActiveRecord::DeleteRestrictionError do
-      @fred.destroy!
+      @fred.hard_destroy
     end
     assert_equal false, @fred.deleted?
     assert_equal false, pebbles.reload.deleted?
@@ -78,7 +78,7 @@ class DependentRestrictTest < Test::Unit::TestCase
     pebbles.destroy
     bambam.destroy
     assert_equal 0, @fred.soft_restrict_children.not_deleted.count
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_id(@fred.id)
   end
 
@@ -87,7 +87,7 @@ class DependentRestrictTest < Test::Unit::TestCase
     @fred.restrict_children << bambam = RestrictChild.new(:name => "bambam")
     assert_equal 2, @fred.reload.restrict_children.count
     assert_raise ActiveRecord::DeleteRestrictionError do
-      @fred.destroy!
+      @fred.hard_destroy
     end
     assert_equal false, @fred.deleted?
     assert_not_nil RestrictChild.find_by_name("pebbles")
@@ -128,7 +128,7 @@ class DependentRestrictTest < Test::Unit::TestCase
     @fred.soft_restrict_one = SoftRestrictOne.new(:name => "bambam")
     assert_equal @fred.reload.soft_restrict_one, SoftRestrictOne.where(:name => "bambam", :parent_id => @fred.id).first
     assert_raise ActiveRecord::DeleteRestrictionError do
-      @fred.destroy!
+      @fred.hard_destroy
     end
     assert_equal false, @fred.deleted?
     assert_not_nil SoftRestrictOne.find_by_name("bambam")
@@ -139,7 +139,7 @@ class DependentRestrictTest < Test::Unit::TestCase
     assert_equal @fred.reload.soft_restrict_one, SoftRestrictOne.where(:name => "bambam", :parent_id => @fred.id).first
     bambam.destroy
     assert_equal true, @fred.reload.soft_restrict_one.deleted?
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.find_by_id(@fred.id)
   end  
 
@@ -147,7 +147,7 @@ class DependentRestrictTest < Test::Unit::TestCase
     @fred.restrict_one = RestrictOne.new(:name => "bambam")
     assert_equal @fred.reload.restrict_one, RestrictOne.where(:name => "bambam", :parent_id => @fred.id).first
     assert_raise ActiveRecord::DeleteRestrictionError do
-      @fred.destroy!
+      @fred.hard_destroy
     end
     assert_equal false, @fred.deleted?
     assert_not_nil RestrictOne.find_by_name("bambam")

--- a/test/non_dependent_test.rb
+++ b/test/non_dependent_test.rb
@@ -22,7 +22,7 @@ class NonDependentTest < Test::Unit::TestCase
   def test_destroy_bang_does_not_destroy_non_dependent_children
     @fred.non_dependent_children << pebbles = NonDependentChild.new(:name => "pebbles")
     assert_equal 1, @fred.reload.non_dependent_children.count
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.where(:name => "fred").first
     assert_not_nil pebbles.reload
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -177,7 +177,7 @@ def setup_db
       t.soft_destroyable
     end
 
-    # used to test before_soft_destroy and before_destroy!
+    # used to test before_soft_destroy and before_hard_destroy
     create_table :soft_callback_children do |t|
       t.string :name
       t.references :callback_parent
@@ -387,7 +387,7 @@ class SoftCallbackChild < ActiveRecord::Base
     raise PreventSoftDestroyError.new
   end
 
-  def before_destroy!
+  def before_hard_destroy
     raise PreventDestroyBangError.new
   end
 end
@@ -399,7 +399,7 @@ class CallbackChild < ActiveRecord::Base
     raise PreventSoftDestroyError.new
   end
 
-  def before_destroy!
+  def before_hard_destroy
     raise PreventDestroyBangError.new
   end
 end

--- a/test/through_associations_test.rb
+++ b/test/through_associations_test.rb
@@ -44,7 +44,7 @@ class ThroughAssociationsTest < Test::Unit::TestCase
     assert_equal 1, @fred.parent_sports.count
     assert_equal 1, @fred.soft_sports.count
     assert_equal 1, @fred.soft_parent_sports.count
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.where(:name => "fred").first
     assert_equal 1, Sport.count
     assert_equal 1, SoftSport.count
@@ -76,7 +76,7 @@ class ThroughAssociationsTest < Test::Unit::TestCase
     assert_equal scar, @fred.soft_nickname
     assert_equal rocky, @fred.parent_nickname.nickname
     assert_equal scar, @fred.soft_parent_nickname.soft_nickname
-    @fred.destroy!
+    @fred.hard_destroy
     assert_nil Parent.where(:name => "fred").first
     assert_equal 1, Nickname.count
     assert_equal 1, SoftNickname.count


### PR DESCRIPTION
Rails 4 introduced its own `destroy!` method. It raises an exception when `destroy` does not succeed. Since Rails calls `destroy!` in its [has_many_association](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/has_many_association.rb#L120), this can result in actually destroying a `soft_destroyable` record!

This PR renames the `destroy!` method to `hard_destroy` as to not conflict with Rails 4's method. Associated before and after filters were renamed as well. Tests pass as expected.